### PR TITLE
Null check for issues before accessing

### DIFF
--- a/updateCurrentIteration.js
+++ b/updateCurrentIteration.js
@@ -80,9 +80,8 @@ function getEpicData(repoId, epicId, index) {
 function getIssues(epicIssues, issues) {
   var issue = issues.shift();
 
-  epicIssues.push(getIssueData(issue.repo_id, issue.issue_number));
-
   if (issues.length > 0) {
+    epicIssues.push(getIssueData(issue.repo_id, issue.issue_number));
     Utilities.sleep(RATE_LIMIT);
     return getIssues(epicIssues, issues);
   } else {


### PR DESCRIPTION
## Done
Moved the access of the issues object within the null check.

Fixes https://github.com/canonical-webteam/zenhub-backlog-updater/issues/11