### PR TITLE
Look up all issue pipelines to be sure

### DIFF
--- a/updateCurrentIteration.js
+++ b/updateCurrentIteration.js
@@ -79,8 +79,10 @@ function getEpicData(repoId, epicId, index) {
 
 function getIssues(epicIssues, issues) {
   var issue = issues.shift();
-
-  epicIssues.push(getIssueData(issue.repo_id, issue.issue_number));
+  
+  if (issue.repo_id && issue.issue_number) {
+    epicIssues.push(getIssueData(issue.repo_id, issue.issue_number));
+  }
   if (issues.length > 0) {
     Utilities.sleep(RATE_LIMIT);
     return getIssues(epicIssues, issues);

--- a/updateCurrentIteration.js
+++ b/updateCurrentIteration.js
@@ -80,7 +80,7 @@ function getEpicData(repoId, epicId, index) {
 function getIssues(epicIssues, issues) {
   var issue = issues.shift();
   
-  if (issue.repo_id && issue.issue_number) {
+  if (issue && issue.repo_id && issue.issue_number) {
     epicIssues.push(getIssueData(issue.repo_id, issue.issue_number));
   }
   if (issues.length > 0) {

--- a/updateCurrentIteration.js
+++ b/updateCurrentIteration.js
@@ -1,5 +1,5 @@
 // ZenHub backlog updater
-// Version: v0.0.1
+// Version: v0.0.2
 // https://github.com/canonical-webteam/zenhub-backlog-updater/
 
 function onOpen() {
@@ -80,8 +80,8 @@ function getEpicData(repoId, epicId, index) {
 function getIssues(epicIssues, issues) {
   var issue = issues.shift();
 
+  epicIssues.push(getIssueData(issue.repo_id, issue.issue_number));
   if (issues.length > 0) {
-    epicIssues.push(getIssueData(issue.repo_id, issue.issue_number));
     Utilities.sleep(RATE_LIMIT);
     return getIssues(epicIssues, issues);
   } else {


### PR DESCRIPTION
So what was happening was it wasn't double checking in last issue in the epic. Therefore, it was relying on the flaky response from Zenhub's epic feed. Which worked most of the time but strangely left off points when calculating the complete value.

Once landed please release `v0.0.2`

Fixes #13 